### PR TITLE
Fix: reset button clears tip button active state

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,11 @@ resetBtn.addEventListener("click", () => {
     people.value = "";
     tipEl.textContent = "$0.00";
     totalEl.textContent = "$0.00";
+
+    // removes active state for each tip button when reset button is clicked
+    buttons.forEach((button) => {
+        button.classList.remove("tip-active");
+    })
 })
 
 function calculateTotal() {


### PR DESCRIPTION
- Added logic to remove the `tip-active` class from all tip percentage buttons when the reset button is clicked.
- This ensures that after a reset, no tip option appears selected, returning the UI to its default state.

**Code added:**
```js
// removes active state for each tip button when reset button is clicked
buttons.forEach((button) => {
    button.classList.remove("tip-active");
})
```

Fix #1 