### PR TITLE
Fix: reset custom tip

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,11 @@ resetBtn.addEventListener("click", () => {
     people.value = "";
     tipEl.textContent = "$0.00";
     totalEl.textContent = "$0.00";
+
+    // removes active state for each tip button when reset button is clicked
+    buttons.forEach((button) => {
+        button.classList.remove("tip-active");
+    })
 })
 
 function calculateTotal() {

--- a/index.js
+++ b/index.js
@@ -39,6 +39,9 @@ resetBtn.addEventListener("click", () => {
     buttons.forEach((button) => {
         button.classList.remove("tip-active");
     })
+
+    // this resets the value of custom tip
+    customBtn.textContent = 'Custom';
 })
 
 function calculateTotal() {


### PR DESCRIPTION
- Added logic to reset the custom tip place holder value to `"Custom"` when the reset button is clicked.
- This ensures the custom tip value always returns to its default state after a reset.

**Code added:**
```js
// this resets the value of custom tip
customBtn.textContent = 'Custom';
```
Fix #2 
