### PR TITLE
Fix: reset people error

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,11 @@ resetBtn.addEventListener("click", () => {
     people.value = "";
     tipEl.textContent = "$0.00";
     totalEl.textContent = "$0.00";
+
+    // removes active state for each tip button when reset button is clicked
+    buttons.forEach((button) => {
+        button.classList.remove("tip-active");
+    })
 })
 
 function calculateTotal() {

--- a/index.js
+++ b/index.js
@@ -39,6 +39,9 @@ resetBtn.addEventListener("click", () => {
     buttons.forEach((button) => {
         button.classList.remove("tip-active");
     })
+
+    // this resets the value of custom tip
+    customBtn.textContent = 'Custom';
 })
 
 function calculateTotal() {

--- a/index.js
+++ b/index.js
@@ -42,6 +42,10 @@ resetBtn.addEventListener("click", () => {
 
     // this resets the value of custom tip
     customBtn.textContent = 'Custom';
+
+    // removes the error message and border highlight when number of people is zero
+    peopleError.style.display = "none"
+    people.style.outline = "none";
 })
 
 function calculateTotal() {


### PR DESCRIPTION
- Added logic to remove the error message and border highlight for the number of people input when the reset button is clicked.
- This ensures any error message or input highlight is cleared after a reset, so the form returns to its original state.

**Code added:**
```js
// removes the error message and border highlight when number of people is zero
peopleError.style.display = "none"
people.style.outline = "none";
```
Fix #3 
